### PR TITLE
IndexOutOfBoundsException if last local subroutine is unused

### DIFF
--- a/cff/CFFDump.java
+++ b/cff/CFFDump.java
@@ -960,7 +960,7 @@ public class CFFDump
         }
 
         for (int lsubrNo = 0; lsubrNo < count; lsubrNo++) {
-            String lsubr = localSubrs.get(lsubrNo);
+            String lsubr = (lsubrNo < localSubrs.size()) ? localSubrs.get(lsubrNo) : null;
             if (lsubr == null) {
                 int[] offLen = getOffsetAndLengthOfSubroutine(lsubrNo, true, fdIdx);
                 sbMain.append("  [").append(lsubrNo).append("] ");


### PR DESCRIPTION
`IndexOutOfBoundsException` is thrown when creating the dump of the last local subroutine that is never called.